### PR TITLE
Add daemon mode support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Calendar Notice is a Rust application that fetches Google Calendar events and provides notifications. It features:
+- OAuth2 authentication with Google
+- SQLite database for token and event storage
+- TUI (Terminal User Interface) using ratatui
+- Daemon mode for background operation
+- Automatic calendar sync and notifications
+
+## Common Commands
+
+### Build and Run
+```bash
+# Build the project
+cargo build
+
+# Run with TUI (default)
+cargo run
+
+# Run in daemon mode (background, no TUI)
+cargo run -- --daemon
+
+# Run release build
+cargo run --release
+```
+
+### Database Setup
+```bash
+# Install diesel CLI (one-time)
+cargo install diesel_cli
+
+# Initialize database
+diesel setup
+
+# Run migrations
+diesel migration run
+```
+
+### Testing
+```bash
+# Run all tests
+cargo test
+
+# Run specific test
+cargo test test_name
+```
+
+## Architecture
+
+### Core Components
+
+1. **OAuth Module** (`src/oauth/`)
+   - Handles Google OAuth2 flow
+   - Spawns redirect server on port 8990
+   - Manages token storage and expiration
+
+2. **Google Calendar Module** (`src/google_calendar/`)
+   - Fetches calendar events from Google API
+   - Extracts meeting links (Zoom, Teams)
+   - Runs sync cron job
+
+3. **Notification Module** (`src/notification/`)
+   - Filters upcoming events
+   - Manages notification timing
+   - Runs notification cron job
+
+4. **TUI Module** (`src/tui/`)
+   - Terminal interface using ratatui
+   - Displays calendar events
+   - Allows user interaction
+
+5. **Repository Module** (`src/repository/`)
+   - Database models and operations
+   - Uses Diesel ORM with SQLite
+
+### Key Design Patterns
+
+- **Async Runtime**: Uses Tokio for async operations
+- **Background Jobs**: Spawns separate tasks for OAuth server, calendar sync, and notifications
+- **CLI Parsing**: Uses clap for command-line arguments
+- **Error Handling**: Currently uses basic error handling (noted as improvement area in comments)
+
+### Database Schema
+
+Two main tables:
+1. `oauth_tokens` - Stores Google OAuth tokens
+2. `events` - Stores calendar event data
+
+## Configuration
+
+1. **OAuth Setup**: Create `oauth_secret.json` from `oauth_secret_sample.json` with Google OAuth credentials
+2. **Environment**: Create `.env` file with `DATABASE_URL=sqlite://db.sqlite`
+3. **Google Cloud**: Configure OAuth2 client with redirect URI `http://localhost:8990/auth`
+
+## Testing Approach
+
+Tests are located within module files using `#[cfg(test)]` blocks. Currently found in:
+- `src/oauth/oauth_secret.rs`
+- `src/oauth/is_token_expired.rs`
+- `src/notification/filter_upcoming_events.rs`

--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ diesel setup
 ```
 cargo run
 ```
+
+TUI を表示せずデーモンとして起動する場合は以下のようにします。
+
+```
+cargo run -- --daemon
+```
+
+`--daemon` オプションはバックグラウンド実行向けで、Ctrl+C で終了できます。
+
+`docs/systemd/calendar-notice.service` に `systemd` 用のサービス例を用意しています。

--- a/docs/systemd/calendar-notice.service
+++ b/docs/systemd/calendar-notice.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Calendar Notice service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/calendar-notice
+ExecStart=/usr/bin/calendar-notice --daemon
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/src/google_calendar/mod.rs
+++ b/src/google_calendar/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt;
-use std::thread;
 use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::sync::watch::Receiver;
 
 use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue};
 
@@ -218,9 +219,14 @@ const SYNC_CALENDAR_INTERVAL_SEC: u16 = 60 * 10;
 const FROM_SUB_SEC: u16 = 60 * 10;
 const TO_ADD_DAYS: u8 = 3;
 
-pub fn spawn_sync_calendar_cron() {
-    tokio::spawn(async {
+pub fn spawn_sync_calendar_cron(mut shutdown_rx: Receiver<bool>) -> JoinHandle<()> {
+    tokio::spawn(async move {
         loop {
+            // シャットダウンシグナルをチェック
+            if *shutdown_rx.borrow() {
+                break;
+            }
+
             let latest_token = repository::oauth_token::find_latest().unwrap_or_else(|e| {
                 panic!(
                     "Failed to get latest token in run_sync_calendar_cron_thread: {:?}",
@@ -260,9 +266,17 @@ pub fn spawn_sync_calendar_cron() {
                 }
             }
 
-            thread::sleep(Duration::from_secs(SYNC_CALENDAR_INTERVAL_SEC.into()));
+            // sleep 中でもシャットダウンシグナルを受け取れるようにする
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(SYNC_CALENDAR_INTERVAL_SEC.into())) => {},
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            }
         }
-    });
+    })
 }
 
 pub async fn sync_events(oauth_token: OAuthToken) -> Result<(), Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,17 @@ mod repository;
 mod schema;
 mod tui;
 
+use clap::Parser;
 use google_calendar::spawn_sync_calendar_cron;
 use notification::spawn_notification_cron;
 use oauth::spawn_redirect_server;
 use tui::show_tui;
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    daemon: bool,
+}
 
 /**
 functoin..
@@ -31,11 +38,19 @@ improvement..
 */
 #[tokio::main]
 async fn main() {
+    let cli = Cli::parse();
+
     spawn_redirect_server();
 
     spawn_notification_cron();
 
     spawn_sync_calendar_cron();
 
-    show_tui();
+    if !cli.daemon {
+        show_tui();
+    } else {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to listen for ctrl_c");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,17 +40,30 @@ improvement..
 async fn main() {
     let cli = Cli::parse();
 
-    spawn_redirect_server();
+    // シャットダウンシグナル用のチャンネルを作成
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-    spawn_notification_cron();
-
-    spawn_sync_calendar_cron();
+    // 各タスクにシャットダウンレシーバーを渡す
+    let server_handle = spawn_redirect_server(shutdown_rx.clone());
+    let notification_handle = spawn_notification_cron(shutdown_rx.clone());
+    let sync_handle = spawn_sync_calendar_cron(shutdown_rx.clone());
 
     if !cli.daemon {
-        show_tui();
+        show_tui(shutdown_tx.clone());
     } else {
+        // Ctrl-C を待機
         tokio::signal::ctrl_c()
             .await
             .expect("failed to listen for ctrl_c");
+        
+        println!("Shutting down...");
     }
+
+    // シャットダウンシグナルを送信
+    let _ = shutdown_tx.send(true);
+
+    // すべてのタスクの終了を待つ
+    let _ = tokio::join!(server_handle, notification_handle, sync_handle);
+    
+    println!("Shutdown complete");
 }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -1,4 +1,6 @@
 use std::{io, process::Command};
+use tokio::task::JoinHandle;
+use tokio::sync::watch::Receiver;
 
 use filter_upcoming_events::filter_upcoming_events;
 
@@ -11,9 +13,14 @@ mod filter_upcoming_events;
 const NOTIFICATION_INTERVAL_SEC: u16 = 60;
 pub const NOTIFICATION_PERIOD_DAYS: i64 = 7;
 
-pub fn spawn_notification_cron() {
-    tokio::spawn(async {
+pub fn spawn_notification_cron(mut shutdown_rx: Receiver<bool>) -> JoinHandle<()> {
+    tokio::spawn(async move {
         loop {
+            // シャットダウンシグナルをチェック
+            if *shutdown_rx.borrow() {
+                break;
+            }
+
             let now = chrono::Local::now();
             let events = repository::event::find_many(EventFindMany {
                 from: Some(now.to_rfc3339()),
@@ -42,12 +49,17 @@ pub fn spawn_notification_cron() {
                 Err(e) => println!("Failed to get events: {:?}", e),
             }
 
-            tokio::time::sleep(tokio::time::Duration::from_secs(
-                NOTIFICATION_INTERVAL_SEC.into(),
-            ))
-            .await;
+            // sleep 中でもシャットダウンシグナルを受け取れるようにする
+            tokio::select! {
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(NOTIFICATION_INTERVAL_SEC.into())) => {},
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            }
         }
-    });
+    })
 }
 
 fn notify(event: Event) -> Result<(), io::Error> {

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -3,6 +3,8 @@ mod oauth_secret;
 
 use rand::{distributions::Alphanumeric, Rng};
 use std::{collections::HashMap, thread, time::Duration};
+use tokio::task::JoinHandle;
+use tokio::sync::watch::Receiver;
 use warp::Filter;
 
 use serde::{Deserialize, Serialize};
@@ -59,16 +61,21 @@ pub fn to_oauth_on_browser() {
     open::that(oauth_url).expect("Failed to open URL in browser");
 }
 
-pub fn spawn_redirect_server() {
-    tokio::spawn(async {
+pub fn spawn_redirect_server(mut shutdown_rx: Receiver<bool>) -> JoinHandle<()> {
+    tokio::spawn(async move {
         let port = Env::new().port;
         let routes = warp::path(AUTH_REDIRECT_PATH)
             .and(warp::query::<std::collections::HashMap<String, String>>())
             .and_then(handle_oauth_redirect);
 
         // println!("HTTP server starting at {}", port.clone());
-        warp::serve(routes).run(([127, 0, 0, 1], port)).await;
-    });
+        let (_, server) = warp::serve(routes)
+            .bind_with_graceful_shutdown(([127, 0, 0, 1], port), async move {
+                let _ = shutdown_rx.changed().await;
+            });
+        
+        server.await;
+    })
 }
 
 async fn handle_oauth_redirect(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 use chrono::Timelike;
+use tokio::sync::watch::Sender;
 use ui::UI;
 
 use crate::repository::{
@@ -8,7 +9,7 @@ use crate::repository::{
 
 mod ui;
 
-pub fn show_tui() {
+pub fn show_tui(shutdown_tx: Sender<bool>) {
     let mut terminal = ratatui::init();
     let events = fetch_today_events();
     let mut ui = UI {
@@ -17,6 +18,9 @@ pub fn show_tui() {
     };
 
     let _ = ui.run(&mut terminal, fetch_today_events);
+
+    // TUI終了時にシャットダウンシグナルを送信
+    let _ = shutdown_tx.send(true);
 
     ratatui::restore();
 }


### PR DESCRIPTION
## Summary
- allow running without the TUI by parsing a `--daemon` flag
- when daemonized wait on `Ctrl+C` for shutdown
- document the option in the README and provide a sample `systemd` unit

## Testing
- `cargo build` *(fails: could not download crates)*
- `cargo run -- --daemon` *(fails: could not download crates)*
